### PR TITLE
Fixed bug where coordinates were returned incorrectly when not cached.

### DIFF
--- a/fields/field.maplocation.php
+++ b/fields/field.maplocation.php
@@ -86,7 +86,7 @@
 
 			// coordinates is an array, split and return
 			if ($coordinates && is_object($coordinates)) {
-				return $coordinates->lng . ', ' . $coordinates->lat;
+				return $coordinates->lat . ', ' . $coordinates->lng;
 			}
 			// return comma delimeted string
 			elseif ($coordinates) {


### PR DESCRIPTION
Specifically, when the coordinates were not cached the coordinates were returned as longitude and latitude. The correct order is latitude and longitude.
